### PR TITLE
I HATE GRADLE - also, Now clones the ninetyNinePercentChain repo into the chain directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ Thumbs.db
 /ios/xcode/native/
 /ios/IOSLauncher.app
 /ios/IOSLauncher.app.dSYM
+
+## ninetyNinePercentChain
+/core/src/com/ninetyninepercentcasino/chain/*

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -36,6 +36,11 @@ for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
+@rem Pulls ninetyNinePercentChain repo
+git clone https://github.com/Icy262/ninetyNinePercentChain.git core/src/com/ninetyninepercentcasino/chain
+git switch main
+git pull
+
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
 


### PR DESCRIPTION
Modified the gradlew.bat so that it automatically clones and then pulls from the ninetyNinePercentChain repo. It clones because the ninetyNinePercentChain code is not included in the ninetyNinePercent repo. If the project has already been run once on a computer, the clone will fail, but we still need the most recent version of the repo, so we pull from main the most recent version.